### PR TITLE
Improve README install steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,40 +8,48 @@ The goal is to automate and document the filtering process for on-chain group ac
  - Fetches all blocks from the last short session to extract all involved identities with tx in shortsession to allAddresses.txt
  - Saves the current discriminationStakeThreshold.txt
  - Filters out against allAdresses.txt: shitflippers, Humans below min stake, and Newbies/Verifieds below 10k IDNA
- - Outputs a idena_strict_whitelist.jsonl (should be 249 addresses for epoch 164 for example)
+ - Outputs an `idena_whitelist.jsonl` file (around 249 addresses in epoch 164, for example)
 
 ## Installation
 
-These instructions are for users new to Python and just want to run build_idena_identities_strict.py locally.
+These instructions assume a fresh Linux/Unix system (the commands work on Debian
+or Ubuntu). They use a Python virtual environment so that `pip` does not attempt
+to modify system packages.
 
-1. **Install Python 3.8 or newer.**
-   - Windows/macOS users can download it from <https://www.python.org/downloads/>.
-   - Linux users should install it via their package manager (e.g. `apt install python3`).
-2. **Install the required Python package.**
-   Open a terminal (or command prompt) and run:
-
-    ```sh
-   pip install requests
+1. **Install Python 3.10+ and the venv module.**
+   ```sh
+   sudo apt update
+   sudo apt install python3 python3-venv git -y
    ```
+   Windows/macOS users can simply install Python from <https://www.python.org/downloads/> and
+   use a terminal/PowerShell for the remaining steps.
 
-   This installs the only third‑party dependency used by the script.
-3. **Download this repository.**
-
-    ```sh
+2. **Clone this repository.**
+   ```sh
    git clone https://github.com/ubiubi18/whitelist_blueprint.git
    cd whitelist_blueprint
    ```
 
-4. **Run the script.**
+3. **Create and activate a virtual environment.**
+   ```sh
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
 
-    ```sh
+4. **Install the required package inside the venv.**
+   ```sh
+   pip install requests
+   ```
+
+5. **Run the script.**
+   ```sh
    python build_idena_identities_strict.py
    ```
 
-   The script will fetch data from the Idena API and produce a file called
-   `idena_strict_whitelist.jsonl` containing the filtered identities. Auxiliary files
-   such as `allAddresses.txt` and `stake_threshold.txt` will be
-   created in the same folder.
+   It will fetch data from the Idena API and produce:
+   - `allAddresses.txt` – all addresses found with short-session transactions
+   - `discriminationStakeThreshold.txt` – current minimum stake
+   - `idena_whitelist.jsonl` – the filtered whitelist
 
 
 ## Legal


### PR DESCRIPTION
## Summary
- document usage of Python virtual env on Debian/Ubuntu
- clarify cloning, installing dependencies and running script
- fix output filename in 'What does it do?' section

## Testing
- `python3 -m py_compile build_idena_identities_strict.py`


------
https://chatgpt.com/codex/tasks/task_e_684fc229fee4832094c9f72d270aef71